### PR TITLE
disable lastlog to remove spurious console output on login

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -5,7 +5,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := dropbear-pv
 LOCAL_DESCRIPTION := dropbear-pv
 
-LOCAL_AUTOTOOLS_CONFIGURE_ARGS := --enable-static
+LOCAL_AUTOTOOLS_CONFIGURE_ARGS := \
+	--enable-static \
+	--disable-lastlog \
+	$(NULL)
+
 LOCAL_LIBRARIES += zlib
 
 LOCAL_CLEAN_DIRS := $(call local-get-build-dir)/usr/share/ $(call local-get-build-dir)/usr/include/


### PR DESCRIPTION
Removes non critical errors on login to pv dropbear:

[3495] Jun 18 09:16:52 lastlog_perform_login: Couldn't stat /var/log/lastlog: No such file or directory
[3495] Jun 18 09:16:52 lastlog_openseek: /var/log/lastlog is not a file or directory!
[3495] Jun 18 09:16:52 wtmp_write: problem writing /dev/null/wtmp: Not a directory
