### PR TITLE
ci: fix kas config paths after meta-pantavisor restructure

### DIFF
--- a/.github/workflows/on-push-raspberrypi-armv8-scarthgap.yaml
+++ b/.github/workflows/on-push-raspberrypi-armv8-scarthgap.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     env:
       target: dropbear-pv
-      configs: .github/configs/shared-vols.yaml:.github/configs/release/raspberrypi-armv8-scarthgap.yaml
+      configs: kas/build-configs/shared-vols.yaml:kas/build-configs/release/raspberrypi-armv8-scarthgap.yaml
     runs-on: ["self-hosted"]
     container:
       image: ghcr.io/pantacor/kas/kas:next-v7


### PR DESCRIPTION
shared-vols.yaml and release configs moved from .github/configs/ to kas/build-configs/ in meta-pantavisor.